### PR TITLE
feat(inventory): add inventory management API with Swagger docs and structured responses

### DIFF
--- a/src/inventory/dto/inventory.dto.ts
+++ b/src/inventory/dto/inventory.dto.ts
@@ -1,0 +1,25 @@
+// src/inventory/inventory.dto.ts
+import { IsString, IsInt, Min, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MoveStockDto {
+  @ApiProperty() @IsString() sku: string;
+  @ApiProperty() @IsString() fromLocation: string;
+  @ApiProperty() @IsString() toLocation: string;
+  @ApiProperty() @IsInt() @Min(1) quantity: number;
+}
+
+export class TransferStockDto {
+  @ApiProperty({ type: [MoveStockDto] })
+  @ValidateNested({ each: true })
+  @Type(() => MoveStockDto)
+  movements: MoveStockDto[];
+}
+
+export class AdjustStockDto {
+  @ApiProperty() @IsString() sku: string;
+  @ApiProperty() @IsString() locationId: string;
+  @ApiProperty() @IsInt() quantityChange: number;
+  @ApiProperty() @IsString() reason: string;
+}

--- a/src/inventory/entities/inventory-item.entity.ts
+++ b/src/inventory/entities/inventory-item.entity.ts
@@ -1,0 +1,17 @@
+// src/inventory/entities/inventory-item.entity.ts
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('inventory_items')
+export class InventoryItem {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  sku: string;
+
+  @Column()
+  locationId: string;
+
+  @Column('int')
+  quantity: number;
+}

--- a/src/inventory/entities/stock-adjustment.entity.ts
+++ b/src/inventory/entities/stock-adjustment.entity.ts
@@ -1,0 +1,23 @@
+// src/inventory/entities/stock-adjustment.entity.ts
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('stock_adjustments')
+export class StockAdjustment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  sku: string;
+
+  @Column()
+  locationId: string;
+
+  @Column('int')
+  quantityChange: number;
+
+  @Column()
+  reason: string;
+
+  @CreateDateColumn()
+  adjustedAt: Date;
+}

--- a/src/inventory/entities/stock-movement.entity.ts
+++ b/src/inventory/entities/stock-movement.entity.ts
@@ -1,0 +1,23 @@
+// src/inventory/entities/stock-movement.entity.ts
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('stock_movements')
+export class StockMovement {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  sku: string;
+
+  @Column()
+  fromLocation: string;
+
+  @Column()
+  toLocation: string;
+
+  @Column('int')
+  quantity: number;
+
+  @CreateDateColumn()
+  movedAt: Date;
+}

--- a/src/inventory/inventory.controller.ts
+++ b/src/inventory/inventory.controller.ts
@@ -1,0 +1,39 @@
+// src/inventory/inventory.controller.ts
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { InventoryService } from './inventory.service';
+import { MoveStockDto, TransferStockDto, AdjustStockDto } from './inventory.dto';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@ApiTags('Inventory')
+@Controller('inventory')
+export class InventoryController {
+  constructor(private readonly inventoryService: InventoryService) {}
+
+  @Post('move')
+  @ApiOperation({ summary: 'Move stock between locations' })
+  @ApiResponse({ status: 201, description: 'Stock moved successfully' })
+  moveStock(@Body() dto: MoveStockDto) {
+    return this.inventoryService.moveStock(dto);
+  }
+
+  @Get('levels')
+  @ApiOperation({ summary: 'Get current stock levels' })
+  @ApiResponse({ status: 200, description: 'Current inventory levels' })
+  getStockLevels() {
+    return this.inventoryService.getStockLevels();
+  }
+
+  @Post('transfer')
+  @ApiOperation({ summary: 'Transfer stock between multiple locations' })
+  @ApiResponse({ status: 201, description: 'Stock transfer successful' })
+  transferStock(@Body() dto: TransferStockDto) {
+    return this.inventoryService.transferStock(dto);
+  }
+
+  @Post('adjust')
+  @ApiOperation({ summary: 'Adjust stock levels' })
+  @ApiResponse({ status: 201, description: 'Stock adjusted successfully' })
+  adjustStock(@Body() dto: AdjustStockDto) {
+    return this.inventoryService.adjustStock(dto);
+  }
+}

--- a/src/inventory/inventory.module.ts
+++ b/src/inventory/inventory.module.ts
@@ -1,0 +1,17 @@
+// src/inventory/inventory.module.ts
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { InventoryController } from './inventory.controller';
+import { InventoryService } from './inventory.service';
+import { InventoryItem } from './entities/inventory-item.entity';
+import { StockMovement } from './entities/stock-movement.entity';
+import { StockAdjustment } from './entities/stock-adjustment.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([InventoryItem, StockMovement, StockAdjustment]),
+  ],
+  controllers: [InventoryController],
+  providers: [InventoryService],
+})
+export class InventoryModule {}

--- a/src/inventory/inventory.service.ts
+++ b/src/inventory/inventory.service.ts
@@ -1,0 +1,55 @@
+// src/inventory/inventory.service.ts
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InventoryItem } from './entities/inventory-item.entity';
+import { StockMovement } from './entities/stock-movement.entity';
+import { StockAdjustment } from './entities/stock-adjustment.entity';
+import { MoveStockDto, TransferStockDto, AdjustStockDto } from './dto/inventory.dto';
+
+@Injectable()
+export class InventoryService {
+  constructor(
+    @InjectRepository(InventoryItem)
+    private readonly itemRepo: Repository<InventoryItem>,
+    @InjectRepository(StockMovement)
+    private readonly movementRepo: Repository<StockMovement>,
+    @InjectRepository(StockAdjustment)
+    private readonly adjustmentRepo: Repository<StockAdjustment>,
+  ) {}
+
+  async moveStock(dto: MoveStockDto) {
+    await this.adjustInventory(dto.sku, dto.fromLocation, -dto.quantity);
+    await this.adjustInventory(dto.sku, dto.toLocation, dto.quantity);
+    const result = await this.movementRepo.save({ ...dto });
+    return { success: true, message: 'Stock moved successfully', data: result };
+  }
+
+  async getStockLevels() {
+    const data = await this.itemRepo.find();
+    return { success: true, message: 'Stock levels retrieved', data };
+  }
+
+  async transferStock(dto: TransferStockDto) {
+    const results = [];
+    for (const move of dto.movements) {
+      results.push(await this.moveStock(move));
+    }
+    return { success: true, message: 'Stock transfer completed', data: results };
+  }
+
+  async adjustStock(dto: AdjustStockDto) {
+    await this.adjustInventory(dto.sku, dto.locationId, dto.quantityChange);
+    const result = await this.adjustmentRepo.save(dto);
+    return { success: true, message: 'Stock adjusted', data: result };
+  }
+
+  private async adjustInventory(sku: string, locationId: string, change: number) {
+    let item = await this.itemRepo.findOne({ where: { sku, locationId } });
+    if (!item) {
+      item = this.itemRepo.create({ sku, locationId, quantity: 0 });
+    }
+    item.quantity += change;
+    await this.itemRepo.save(item);
+  }
+}


### PR DESCRIPTION
## 🔧 Summary

This PR introduces the core functionality for inventory and stock movement management, enabling accurate tracking, transfer, and adjustment of stock across multiple locations.

---

## ✅ Features Implemented

- **Inventory Endpoints**
  - `POST /inventory/move`: Move stock from one location to another
  - `POST /inventory/transfer`: Bulk move stock via list of movements
  - `POST /inventory/adjust`: Manually adjust inventory count
  - `GET /inventory/levels`: Get current inventory across locations

- **Entities**
  - `InventoryItem`, `StockMovement`, `StockAdjustment`

- **Swagger Documentation**
  - `@ApiTags`, `@ApiOperation`, `@ApiResponse`
  - DTOs documented with `@ApiProperty`

- **Standardized API Responses**
  - Uniform `{ success, message, data }` format

---

## 📂 Affected Files

```

src/inventory/
├── entities/
│   ├── inventory-item.entity.ts
│   ├── stock-movement.entity.ts
│   └── stock-adjustment.entity.ts
├── inventory.controller.ts
├── inventory.service.ts
├── inventory.module.ts
└── inventory.dto.ts

```

---

## 🔒 Future Work

- Auth guard for admin-only adjustments
- Stock threshold alerts
- CSV or Excel export support

---

## 📌 Related Tickets

Closes #40
