### PR TITLE
feat: implemented Settings Resource Module

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "typescript-config/is-valid": "off"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 ## License
 
 Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.0",
+        "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/terminus": "^11.0.0",
@@ -37,7 +38,7 @@
         "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
-        "@types/node": "^22.10.7",
+        "@types/node": "^22.17.2",
         "@types/pg": "^8.15.5",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
@@ -2249,6 +2250,26 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/passport": {

--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "migration:run": "typeorm migration:run"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.0",
+    "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/terminus": "^11.0.0",
@@ -48,7 +50,7 @@
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "^22.10.7",
+    "@types/node": "^22.17.2",
     "@types/pg": "^8.15.5",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",

--- a/src/database/seeds/settings.seed.ts
+++ b/src/database/seeds/settings.seed.ts
@@ -1,0 +1,331 @@
+import { DataSource } from 'typeorm';
+import { Setting, SettingScope, SettingType, SettingCategory } from '../../settings/entities/setting.entity';
+
+export async function seedSettings(dataSource: DataSource): Promise<void> {
+  const settingRepository = dataSource.getRepository(Setting);
+
+  const defaultSettings = [
+    {
+      key: 'app.name',
+      value: 'LyricsFlip Inventory',
+      type: SettingType.STRING,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.GENERAL,
+      description: 'Application name displayed in the interface',
+      isReadonly: false,
+    },
+    {
+      key: 'app.version',
+      value: '1.0.0',
+      type: SettingType.STRING,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.SYSTEM,
+      description: 'Current application version',
+      isReadonly: true,
+    },
+    {
+      key: 'app.timezone',
+      value: 'UTC',
+      type: SettingType.STRING,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.GENERAL,
+      description: 'Default system timezone',
+      validation: {
+        required: true,
+        options: ['UTC', 'America/New_York', 'Europe/London', 'Asia/Tokyo'],
+      },
+    },
+    {
+      key: 'app.language',
+      value: 'en',
+      type: SettingType.STRING,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.GENERAL,
+      description: 'Default system language',
+      validation: {
+        required: true,
+        options: ['en', 'es', 'fr', 'de'],
+      },
+    },
+
+    {
+      key: 'security.session_timeout',
+      value: '3600',
+      type: SettingType.NUMBER,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.SECURITY,
+      description: 'Session timeout in seconds',
+      validation: {
+        required: true,
+        min: 300,
+        max: 86400,
+      },
+      defaultValue: '3600',
+    },
+    {
+      key: 'security.password_min_length',
+      value: '8',
+      type: SettingType.NUMBER,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.SECURITY,
+      description: 'Minimum password length requirement',
+      validation: {
+        required: true,
+        min: 6,
+        max: 128,
+      },
+      defaultValue: '8',
+    },
+    {
+      key: 'security.max_login_attempts',
+      value: '5',
+      type: SettingType.NUMBER,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.SECURITY,
+      description: 'Maximum login attempts before account lockout',
+      validation: {
+        required: true,
+        min: 3,
+        max: 10,
+      },
+      defaultValue: '5',
+    },
+    {
+      key: 'security.enable_2fa',
+      value: 'false',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.SECURITY,
+      description: 'Enable two-factor authentication',
+      defaultValue: 'false',
+    },
+
+    {
+      key: 'inventory.low_stock_threshold',
+      value: '10',
+      type: SettingType.NUMBER,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.INVENTORY,
+      description: 'Default low stock threshold for items',
+      validation: {
+        required: true,
+        min: 0,
+        max: 1000,
+      },
+      defaultValue: '10',
+    },
+    {
+      key: 'inventory.auto_reorder_enabled',
+      value: 'false',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.INVENTORY,
+      description: 'Enable automatic reordering when stock is low',
+      defaultValue: 'false',
+    },
+    {
+      key: 'inventory.default_unit_of_measure',
+      value: 'piece',
+      type: SettingType.STRING,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.INVENTORY,
+      description: 'Default unit of measure for new items',
+      validation: {
+        required: true,
+        options: ['piece', 'kg', 'liter', 'meter', 'box', 'case'],
+      },
+      defaultValue: 'piece',
+    },
+    {
+      key: 'inventory.enable_batch_tracking',
+      value: 'true',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.INVENTORY,
+      description: 'Enable batch/lot number tracking for items',
+      defaultValue: 'true',
+    },
+    {
+      key: 'inventory.enable_expiry_tracking',
+      value: 'true',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.INVENTORY,
+      description: 'Enable expiry date tracking for items',
+      defaultValue: 'true',
+    },
+
+    {
+      key: 'notifications.email_enabled',
+      value: 'true',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.NOTIFICATIONS,
+      description: 'Enable email notifications',
+      defaultValue: 'true',
+    },
+    {
+      key: 'notifications.low_stock_alerts',
+      value: 'true',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.NOTIFICATIONS,
+      description: 'Send alerts when items are low in stock',
+      defaultValue: 'true',
+    },
+    {
+      key: 'notifications.expiry_alerts_days',
+      value: '30',
+      type: SettingType.NUMBER,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.NOTIFICATIONS,
+      description: 'Days before expiry to send alerts',
+      validation: {
+        required: true,
+        min: 1,
+        max: 365,
+      },
+      defaultValue: '30',
+    },
+    {
+      key: 'notifications.purchase_order_approval',
+      value: 'true',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.NOTIFICATIONS,
+      description: 'Send notifications for purchase order approvals',
+      defaultValue: 'true',
+    },
+
+    {
+      key: 'reports.default_date_range',
+      value: '30',
+      type: SettingType.NUMBER,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.REPORTING,
+      description: 'Default date range for reports in days',
+      validation: {
+        required: true,
+        min: 1,
+        max: 365,
+      },
+      defaultValue: '30',
+    },
+    {
+      key: 'reports.auto_export_format',
+      value: 'pdf',
+      type: SettingType.STRING,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.REPORTING,
+      description: 'Default export format for reports',
+      validation: {
+        required: true,
+        options: ['pdf', 'excel', 'csv'],
+      },
+      defaultValue: 'pdf',
+    },
+    {
+      key: 'reports.include_charts',
+      value: 'true',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.REPORTING,
+      description: 'Include charts in generated reports',
+      defaultValue: 'true',
+    },
+
+    {
+      key: 'appearance.theme',
+      value: 'light',
+      type: SettingType.STRING,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.APPEARANCE,
+      description: 'Default application theme',
+      validation: {
+        required: true,
+        options: ['light', 'dark', 'auto'],
+      },
+      defaultValue: 'light',
+    },
+    {
+      key: 'appearance.items_per_page',
+      value: '25',
+      type: SettingType.NUMBER,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.APPEARANCE,
+      description: 'Default number of items to display per page',
+      validation: {
+        required: true,
+        min: 10,
+        max: 100,
+      },
+      defaultValue: '25',
+    },
+    {
+      key: 'appearance.show_item_images',
+      value: 'true',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.COMPANY,
+      category: SettingCategory.APPEARANCE,
+      description: 'Show item images in lists and tables',
+      defaultValue: 'true',
+    },
+
+    {
+      key: 'integrations.api_rate_limit',
+      value: '1000',
+      type: SettingType.NUMBER,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.INTEGRATIONS,
+      description: 'API rate limit per hour',
+      validation: {
+        required: true,
+        min: 100,
+        max: 10000,
+      },
+      defaultValue: '1000',
+    },
+    {
+      key: 'integrations.webhook_timeout',
+      value: '30',
+      type: SettingType.NUMBER,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.INTEGRATIONS,
+      description: 'Webhook timeout in seconds',
+      validation: {
+        required: true,
+        min: 5,
+        max: 300,
+      },
+      defaultValue: '30',
+    },
+    {
+      key: 'integrations.enable_webhooks',
+      value: 'true',
+      type: SettingType.BOOLEAN,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.INTEGRATIONS,
+      description: 'Enable webhook functionality',
+      defaultValue: 'true',
+    },
+  ];
+
+  for (const settingData of defaultSettings) {
+    const existingSetting = await settingRepository.findOne({
+      where: {
+        key: settingData.key,
+        scope: settingData.scope,
+        companyId: undefined, 
+      },
+    });
+
+    if (!existingSetting) {
+      const setting = settingRepository.create(settingData);
+      await settingRepository.save(setting);
+    }
+  }
+
+  console.log(` Seeded ${defaultSettings.length} default settings`);
+}
+
+

--- a/src/migrations/xxxx-create-settings-tables.ts
+++ b/src/migrations/xxxx-create-settings-tables.ts
@@ -1,0 +1,238 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateSettingsTables1700000000000 implements MigrationInterface {
+  name = 'CreateSettingsTables1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'settings',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'key',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            name: 'value',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'type',
+            type: 'enum',
+            enum: ['string', 'number', 'boolean', 'json', 'array'],
+            default: "'string'",
+          },
+          {
+            name: 'scope',
+            type: 'enum',
+            enum: ['system', 'company'],
+            default: "'system'",
+          },
+          {
+            name: 'category',
+            type: 'enum',
+            enum: [
+              'general',
+              'security',
+              'notifications',
+              'inventory',
+              'reporting',
+              'integrations',
+              'appearance',
+              'system',
+            ],
+            default: "'general'",
+          },
+          {
+            name: 'companyId',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'description',
+            type: 'varchar',
+            length: '500',
+            isNullable: true,
+          },
+          {
+            name: 'validation',
+            type: 'json',
+            isNullable: true,
+          },
+          {
+            name: 'metadata',
+            type: 'json',
+            isNullable: true,
+          },
+          {
+            name: 'isActive',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'isReadonly',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'defaultValue',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'createdBy',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'updatedBy',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'setting_history',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'settingId',
+            type: 'uuid',
+          },
+          {
+            name: 'settingKey',
+            type: 'varchar',
+            length: '255',
+          },
+          {
+            name: 'oldValue',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'newValue',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'changeType',
+            type: 'enum',
+            enum: ['created', 'updated', 'deleted', 'restored'],
+          },
+          {
+            name: 'reason',
+            type: 'varchar',
+            length: '500',
+            isNullable: true,
+          },
+          {
+            name: 'changedBy',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'metadata',
+            type: 'json',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['settingId'],
+            referencedTableName: 'settings',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['changedBy'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'SET NULL',
+          },
+        ],
+      }),
+    );
+
+    // Create indexes
+    await queryRunner.createIndex(
+      'settings',
+      new TableIndex({
+        name: 'IDX_SETTINGS_CATEGORY',
+        columnNames: ['category'],
+        isUnique: false,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'settings',
+      new TableIndex({
+        name: 'IDX_SETTINGS_COMPANY_ID',
+        columnNames: ['companyId'],
+        isUnique: false,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'settings',
+      new TableIndex({
+        name: 'IDX_SETTINGS_UNIQUE_KEY_SCOPE_COMPANY',
+        columnNames: ['key', 'scope', 'companyId'],
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'setting_history',
+      new TableIndex({
+        name: 'IDX_SETTING_HISTORY_CREATED_AT',
+        columnNames: ['createdAt'],
+        isUnique: false,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('setting_history', 'IDX_SETTING_HISTORY_CREATED_AT');
+    await queryRunner.dropIndex('settings', 'IDX_SETTINGS_UNIQUE_KEY_SCOPE_COMPANY');
+    await queryRunner.dropIndex('settings', 'IDX_SETTINGS_COMPANY_ID');
+    await queryRunner.dropIndex('settings', 'IDX_SETTINGS_CATEGORY');
+
+    await queryRunner.dropTable('setting_history');
+    await queryRunner.dropTable('settings');
+  }
+}

--- a/src/settings/controllers/company-settings.controller.ts
+++ b/src/settings/controllers/company-settings.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Get, Param, ParseUUIDPipe, Put, Query, UseGuards, Req } from "@nestjs/common";
+import { JwtAuthGuard } from "src/auth/guards/jwt-auth.guard";
+import { SettingQueryDto } from "../dto/setting-query.dto";
+import { SettingResponseDto } from "../dto/setting-response.dto";
+import { UpdateSettingValueDto } from "../dto/setting-value.dto";
+import { SettingsService } from "../services/settings.service";
+
+@Controller('companies/:companyId/settings')
+@UseGuards(JwtAuthGuard)
+export class CompanySettingsController {
+  constructor(private readonly settingsService: SettingsService) {}
+
+  @Get()
+  async getCompanySettings(
+    @Param('companyId', ParseUUIDPipe) companyId: string,
+    @Query() query: SettingQueryDto,
+  ): Promise<SettingResponseDto[]> {
+    return this.settingsService.getCompanySettings(companyId, query);
+  }
+
+  @Put(':key')
+  async updateCompanySetting(
+    @Param('companyId', ParseUUIDPipe) companyId: string,
+    @Param('key') key: string,
+    @Body() updateDto: UpdateSettingValueDto,
+    @Req() req: any,
+  ): Promise<SettingResponseDto> {
+    return this.settingsService.updateByKey(key, updateDto, req.user.sub, companyId);
+  }
+
+  @Get(':key')
+  async getCompanySetting(
+    @Param('companyId', ParseUUIDPipe) companyId: string,
+    @Param('key') key: string,
+  ): Promise<SettingResponseDto> {
+    return this.settingsService.findByKey(key, companyId);
+  }
+
+  @Get(':key/history')
+  async getCompanySettingHistory(
+    @Param('companyId', ParseUUIDPipe) companyId: string,
+    @Param('key') key: string,
+    @Query('limit') limit?: number,
+  ) {
+    return this.settingsService.getSettingHistory(key, companyId, limit);
+  }
+}

--- a/src/settings/controllers/settings.controller.ts
+++ b/src/settings/controllers/settings.controller.ts
@@ -1,0 +1,113 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+  HttpStatus,
+  HttpCode,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { SettingsService } from '../services/settings.service';
+import { CreateSettingDto } from '../dto/create-setting.dto';
+import { UpdateSettingDto } from '../dto/update-setting.dto';
+import { UpdateSettingValueDto } from '../dto/setting-value.dto';
+import { SettingQueryDto } from '../dto/setting-query.dto';
+import { SettingResponseDto } from '../dto/setting-response.dto';
+import { RestoreSettingsDto } from '../dto/setting-backup.dto';
+import { SettingCategory } from '../entities/setting.entity';
+
+@Controller('settings')
+@UseGuards(JwtAuthGuard)
+export class SettingsController {
+  constructor(private readonly settingsService: SettingsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body() createSettingDto: CreateSettingDto,
+    @Request() req: any,
+  ): Promise<SettingResponseDto> {
+    return this.settingsService.create(createSettingDto, req.user.sub);
+  }
+
+  @Get()
+  async findAll(@Query() query: SettingQueryDto): Promise<SettingResponseDto[]> {
+    return this.settingsService.findAll(query);
+  }
+
+  @Get('categories')
+  async getCategories(): Promise<{ category: SettingCategory; count: number }[]> {
+    return this.settingsService.getCategories();
+  }
+
+  @Get('backup')
+  async createBackup(
+    @Query('scope') scope?: string,
+    @Query('companyId') companyId?: string,
+    @Query('description') description?: string,
+  ) {
+    return this.settingsService.createBackup(scope as any, companyId, description);
+  }
+
+  @Post('restore')
+  @HttpCode(HttpStatus.OK)
+  async restoreFromBackup(
+    @Body() restoreDto: RestoreSettingsDto,
+    @Request() req: any,
+  ) {
+    return this.settingsService.restoreFromBackup(restoreDto, req.user.sub);
+  }
+
+  @Get(':key')
+  async findByKey(
+    @Param('key') key: string,
+    @Query('companyId') companyId?: string,
+  ): Promise<SettingResponseDto> {
+    return this.settingsService.findByKey(key, companyId);
+  }
+
+  @Put(':key')
+  async updateByKey(
+    @Param('key') key: string,
+    @Body() updateDto: UpdateSettingValueDto,
+    @Request() req: any,
+    @Query('companyId') companyId?: string,
+  ): Promise<SettingResponseDto> {
+    return this.settingsService.updateByKey(key, updateDto, req.user.sub, companyId);
+  }
+
+  @Get(':key/history')
+  async getSettingHistory(
+    @Param('key') key: string,
+    @Query('companyId') companyId?: string,
+    @Query('limit') limit?: number,
+  ) {
+    return this.settingsService.getSettingHistory(key, companyId, limit);
+  }
+
+  @Put(':id/full')
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateDto: UpdateSettingDto,
+    @Request() req: any,
+  ): Promise<SettingResponseDto> {
+    return this.settingsService.update(id, updateDto, req.user.sub);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async delete(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: any,
+  ): Promise<void> {
+    return this.settingsService.delete(id, req.user.sub);
+  }
+}
+

--- a/src/settings/dto/create-setting.dto.ts
+++ b/src/settings/dto/create-setting.dto.ts
@@ -1,0 +1,69 @@
+import {
+  IsEnum,
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsUUID,
+  MaxLength,
+  IsObject,
+} from 'class-validator';
+import { SettingScope, SettingType, SettingCategory } from '../entities/setting.entity';
+
+export class CreateSettingDto {
+  @IsString()
+  @MaxLength(255)
+  key: string;
+
+  @IsOptional()
+  @IsString()
+  value?: string;
+
+  @IsEnum(SettingType)
+  type: SettingType;
+
+  @IsEnum(SettingScope)
+  scope: SettingScope;
+
+  @IsEnum(SettingCategory)
+  category: SettingCategory;
+
+  @IsOptional()
+  @IsUUID()
+  companyId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @IsOptional()
+  @IsObject()
+  validation?: {
+    required?: boolean;
+    min?: number;
+    max?: number;
+    minLength?: number;
+    maxLength?: number;
+    pattern?: string;
+    options?: string[];
+  };
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  isReadonly?: boolean;
+
+  @IsOptional()
+  @IsString()
+  defaultValue?: string;
+}
+
+
+

--- a/src/settings/dto/setting-backup.dto.ts
+++ b/src/settings/dto/setting-backup.dto.ts
@@ -1,0 +1,27 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
+import { SettingResponseDto } from './setting-response.dto';
+import { CreateSettingDto } from './create-setting.dto';
+
+export class SettingsBackupDto {
+  @IsArray()
+  settings: SettingResponseDto[];
+
+  @IsString()
+  version: string;
+
+  @IsString()
+  createdAt: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}
+
+export class RestoreSettingsDto {
+  @IsArray()
+  settings: CreateSettingDto[];
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/src/settings/dto/setting-query.dto.ts
+++ b/src/settings/dto/setting-query.dto.ts
@@ -1,0 +1,31 @@
+import { IsOptional, IsEnum, IsUUID, IsString, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { SettingScope, SettingCategory } from '../entities/setting.entity';
+
+export class SettingQueryDto {
+  @IsOptional()
+  @IsEnum(SettingScope)
+  scope?: SettingScope;
+
+  @IsOptional()
+  @IsEnum(SettingCategory)
+  category?: SettingCategory;
+
+  @IsOptional()
+  @IsUUID()
+  companyId?: string;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => value === 'true')
+  @IsBoolean()
+  includeInactive?: boolean;
+
+  @IsOptional()
+  @Transform(({ value }) => value === 'true')
+  @IsBoolean()
+  includeReadonly?: boolean;
+}

--- a/src/settings/dto/setting-response.dto.ts
+++ b/src/settings/dto/setting-response.dto.ts
@@ -1,0 +1,23 @@
+import { SettingScope, SettingType, SettingCategory } from '../entities/setting.entity';
+
+export class SettingResponseDto {
+  id: string;
+  key: string;
+  value: string;
+  parsedValue: any;
+  type: SettingType;
+  scope: SettingScope;
+  category: SettingCategory;
+  companyId?: string;
+  description?: string;
+  validation?: any;
+  metadata?: Record<string, any>;
+  isActive: boolean;
+  isReadonly: boolean;
+  defaultValue?: string;
+  createdBy?: string;
+  updatedBy?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+

--- a/src/settings/dto/setting-value.dto.ts
+++ b/src/settings/dto/setting-value.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateSettingValueDto {
+  @IsString()
+  value: string;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}
+

--- a/src/settings/dto/update-setting.dto.ts
+++ b/src/settings/dto/update-setting.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType, OmitType } from '@nestjs/mapped-types';
+import { CreateSettingDto } from './create-setting.dto';
+
+export class UpdateSettingDto extends PartialType(
+  OmitType(CreateSettingDto, ['key', 'scope'] as const),
+) {}

--- a/src/settings/entities/setting-history.entity.ts
+++ b/src/settings/entities/setting-history.entity.ts
@@ -1,0 +1,63 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Setting } from './setting.entity';
+import { User } from '../../users/user.entity';
+
+export enum SettingChangeType {
+  CREATED = 'created',
+  UPDATED = 'updated',
+  DELETED = 'deleted',
+  RESTORED = 'restored',
+}
+
+@Entity('setting_history')
+export class SettingHistory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Setting, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'settingId' })
+  setting: Setting;
+
+  @Column({ type: 'uuid' })
+  @Index()
+  settingId: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  settingKey: string;
+
+  @Column({ type: 'text', nullable: true })
+  oldValue: string;
+
+  @Column({ type: 'text', nullable: true })
+  newValue: string;
+
+  @Column({
+    type: 'enum',
+    enum: SettingChangeType,
+  })
+  changeType: SettingChangeType;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  reason: string;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'changedBy' })
+  changedByUser: User;
+
+  @Column({ type: 'uuid', nullable: true })
+  changedBy: string;
+
+  @Column({ type: 'json', nullable: true })
+  metadata: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/settings/entities/setting.entity.ts
+++ b/src/settings/entities/setting.entity.ts
@@ -1,0 +1,181 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../users/user.entity';
+
+export enum SettingScope {
+  SYSTEM = 'system',
+  COMPANY = 'company',
+}
+
+export enum SettingType {
+  STRING = 'string',
+  NUMBER = 'number',
+  BOOLEAN = 'boolean',
+  JSON = 'json',
+  ARRAY = 'array',
+}
+
+export enum SettingCategory {
+  GENERAL = 'general',
+  SECURITY = 'security',
+  NOTIFICATIONS = 'notifications',
+  INVENTORY = 'inventory',
+  REPORTING = 'reporting',
+  INTEGRATIONS = 'integrations',
+  APPEARANCE = 'appearance',
+  SYSTEM = 'system',
+}
+
+@Entity('settings')
+@Index(['key', 'scope', 'companyId'], { unique: true })
+export class Setting {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  @Index()
+  key: string;
+
+  @Column({ type: 'text', nullable: true })
+  value: string;
+
+  @Column({
+    type: 'enum',
+    enum: SettingType,
+    default: SettingType.STRING,
+  })
+  type: SettingType;
+
+  @Column({
+    type: 'enum',
+    enum: SettingScope,
+    default: SettingScope.SYSTEM,
+  })
+  @Index()
+  scope: SettingScope;
+
+  @Column({
+    type: 'enum',
+    enum: SettingCategory,
+    default: SettingCategory.GENERAL,
+  })
+  @Index()
+  category: SettingCategory;
+
+  @Column({ type: 'uuid', nullable: true })
+  @Index()
+  companyId: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  description: string;
+
+  @Column({ type: 'json', nullable: true })
+  validation: {
+    required?: boolean;
+    min?: number;
+    max?: number;
+    minLength?: number;
+    maxLength?: number;
+    pattern?: string;
+    options?: string[];
+  };
+
+  @Column({ type: 'json', nullable: true })
+  metadata: Record<string, any>;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  isReadonly: boolean;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  defaultValue: string;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'createdBy' })
+  createdByUser: User;
+
+  @Column({ type: 'uuid', nullable: true })
+  createdBy: string;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'updatedBy' })
+  updatedByUser: User;
+
+  @Column({ type: 'uuid', nullable: true })
+  updatedBy: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+  Id: string | undefined;
+
+  // Helper methods
+  getParsedValue(): any {
+    if (!this.value) return this.getDefaultValue();
+
+    try {
+      switch (this.type) {
+        case SettingType.BOOLEAN:
+          return this.value.toLowerCase() === 'true';
+        case SettingType.NUMBER:
+          return parseFloat(this.value);
+        case SettingType.JSON:
+        case SettingType.ARRAY:
+          return JSON.parse(this.value);
+        default:
+          return this.value;
+      }
+    } catch {
+      return this.getDefaultValue();
+    }
+  }
+
+  getDefaultValue(): any {
+    if (!this.defaultValue) return null;
+
+    try {
+      switch (this.type) {
+        case SettingType.BOOLEAN:
+          return this.defaultValue.toLowerCase() === 'true';
+        case SettingType.NUMBER:
+          return parseFloat(this.defaultValue);
+        case SettingType.JSON:
+        case SettingType.ARRAY:
+          return JSON.parse(this.defaultValue);
+        default:
+          return this.defaultValue;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  setValue(value: any): void {
+    switch (this.type) {
+      case SettingType.BOOLEAN:
+        this.value = value ? 'true' : 'false';
+        break;
+      case SettingType.NUMBER:
+        this.value = value?.toString();
+        break;
+      case SettingType.JSON:
+      case SettingType.ARRAY:
+        this.value = JSON.stringify(value);
+        break;
+      default:
+        this.value = value?.toString();
+    }
+  }
+}

--- a/src/settings/exceptions/invalid-setting-value.exception.ts
+++ b/src/settings/exceptions/invalid-setting-value.exception.ts
@@ -1,0 +1,7 @@
+import { BadRequestException } from '@nestjs/common';
+
+export class InvalidSettingValueException extends BadRequestException {
+  constructor(key: string, reason: string) {
+    super(`Invalid value for setting '${key}': ${reason}`);
+  }
+}

--- a/src/settings/exceptions/setting-already-exists.exception.ts
+++ b/src/settings/exceptions/setting-already-exists.exception.ts
@@ -1,0 +1,10 @@
+import { ConflictException } from '@nestjs/common';
+
+export class SettingAlreadyExistsException extends ConflictException {
+  constructor(key: string, scope: string, companyId?: string) {
+    const message = companyId
+      ? `Setting with key '${key}' already exists in ${scope} scope for company '${companyId}'`
+      : `Setting with key '${key}' already exists in ${scope} scope`;
+    super(message);
+  }
+}

--- a/src/settings/exceptions/setting-not-found.exception.ts
+++ b/src/settings/exceptions/setting-not-found.exception.ts
@@ -1,0 +1,13 @@
+import { NotFoundException } from '@nestjs/common';
+
+export class SettingNotFoundException extends NotFoundException {
+  constructor(key: string, companyId?: string) {
+    const message = companyId
+      ? `Setting with key '${key}' not found for company '${companyId}'`
+      : `Setting with key '${key}' not found`;
+    super(message);
+  }
+}
+
+
+

--- a/src/settings/exceptions/setting-readonly.exception.ts
+++ b/src/settings/exceptions/setting-readonly.exception.ts
@@ -1,0 +1,7 @@
+import { ForbiddenException } from '@nestjs/common';
+
+export class SettingReadonlyException extends ForbiddenException {
+  constructor(key: string) {
+    super(`Setting '${key}' is read-only and cannot be modified`);
+  }
+}

--- a/src/settings/services/settings.service.ts
+++ b/src/settings/services/settings.service.ts
@@ -1,0 +1,489 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In, IsNull } from 'typeorm';
+import {
+  Setting,
+  SettingScope,
+  SettingCategory,
+  SettingType,
+} from '../entities/setting.entity';
+import {
+  SettingHistory,
+  SettingChangeType,
+} from '../entities/setting-history.entity';
+import { CreateSettingDto } from '../dto/create-setting.dto';
+import { UpdateSettingDto } from '../dto/update-setting.dto';
+import { UpdateSettingValueDto } from '../dto/setting-value.dto';
+import { SettingQueryDto } from '../dto/setting-query.dto';
+import { SettingResponseDto } from '../dto/setting-response.dto';
+import { SettingsBackupDto, RestoreSettingsDto } from '../dto/setting-backup.dto';
+
+@Injectable()
+export class SettingsService {
+  constructor(
+    @InjectRepository(Setting)
+    private readonly settingRepository: Repository<Setting>,
+    @InjectRepository(SettingHistory)
+    private readonly settingHistoryRepository: Repository<SettingHistory>,
+  ) {}
+
+  async create(
+    createSettingDto: CreateSettingDto,
+    userId?: string,
+  ): Promise<SettingResponseDto> {
+const existing = await this.settingRepository.findOne({
+  where: {
+    key: createSettingDto.key,
+    scope: createSettingDto.scope,
+    ...(createSettingDto.companyId
+      ? { companyId: createSettingDto.companyId }
+      : { companyId: IsNull() }),
+  },
+});
+    if (existing) {
+      throw new ConflictException('Setting with this key already exists');
+    }
+
+    if (createSettingDto.scope === SettingScope.COMPANY && !createSettingDto.companyId) {
+      throw new BadRequestException('Company ID is required for company-scoped settings');
+    }
+
+    const setting = this.settingRepository.create({
+      ...createSettingDto,
+      createdBy: userId,
+      updatedBy: userId,
+    });
+
+    if (createSettingDto.value !== undefined) {
+      this.validateSettingValue(setting, createSettingDto.value);
+      setting.setValue(createSettingDto.value);
+    }
+
+    const savedSetting = await this.settingRepository.save(setting);
+
+    await this.logSettingChange(
+      savedSetting,
+      SettingChangeType.CREATED,
+      null,
+      savedSetting.value,
+      userId,
+      'Setting created',
+    );
+
+    return this.toResponseDto(savedSetting);
+  }
+
+  async findAll(query: SettingQueryDto): Promise<SettingResponseDto[]> {
+    const queryBuilder = this.settingRepository.createQueryBuilder('setting');
+
+    if (query.scope) {
+      queryBuilder.andWhere('setting.scope = :scope', { scope: query.scope });
+    }
+
+    if (query.category) {
+      queryBuilder.andWhere('setting.category = :category', {
+        category: query.category,
+      });
+    }
+
+    if (query.companyId) {
+      queryBuilder.andWhere('setting.companyId = :companyId', {
+        companyId: query.companyId,
+      });
+    }
+
+    if (query.search) {
+      queryBuilder.andWhere(
+        '(setting.key ILIKE :search OR setting.description ILIKE :search)',
+        { search: `%${query.search}%` },
+      );
+    }
+
+    if (!query.includeInactive) {
+      queryBuilder.andWhere('setting.isActive = true');
+    }
+
+    if (!query.includeReadonly) {
+      queryBuilder.andWhere('setting.isReadonly = false');
+    }
+
+    queryBuilder.orderBy('setting.category', 'ASC')
+      .addOrderBy('setting.key', 'ASC');
+
+    const settings = await queryBuilder.getMany();
+    return settings.map(setting => this.toResponseDto(setting));
+  }
+
+  async findByKey(
+    key: string,
+    companyId?: string,
+  ): Promise<SettingResponseDto> {
+    const setting = await this.getSettingByKey(key, companyId);
+    return this.toResponseDto(setting);
+  }
+
+  async updateByKey(
+    key: string,
+    updateDto: UpdateSettingValueDto,
+    userId?: string,
+    companyId?: string,
+  ): Promise<SettingResponseDto> {
+    const setting = await this.getSettingByKey(key, companyId);
+
+    if (setting.isReadonly) {
+      throw new ForbiddenException('This setting is read-only');
+    }
+
+    this.validateSettingValue(setting, updateDto.value);
+
+    const oldValue = setting.value;
+    setting.setValue(updateDto.value);
+    setting.updatedBy = userId ?? 'system';
+
+    const updatedSetting = await this.settingRepository.save(setting);
+
+    await this.logSettingChange(
+      setting,
+      SettingChangeType.UPDATED,
+      oldValue,
+      setting.value,
+      userId,
+      updateDto.reason,
+    );
+
+    return this.toResponseDto(updatedSetting);
+  }
+
+  async update(
+    id: string,
+    updateDto: UpdateSettingDto,
+    userId?: string,
+  ): Promise<SettingResponseDto> {
+    const setting = await this.settingRepository.findOne({
+      where: { id },
+    });
+
+    if (!setting) {
+      throw new NotFoundException('Setting not found');
+    }
+
+    if (setting.isReadonly) {
+      throw new ForbiddenException('This setting is read-only');
+    }
+
+    const oldValue = setting.value;
+    Object.assign(setting, updateDto);
+    setting.updatedBy = userId ??  'system';
+
+    if (updateDto.value !== undefined) {
+      this.validateSettingValue(setting, updateDto.value);
+      setting.setValue(updateDto.value);
+    }
+
+    const updatedSetting = await this.settingRepository.save(setting);
+
+    if (oldValue !== setting.value) {
+      await this.logSettingChange(
+        setting,
+        SettingChangeType.UPDATED,
+        oldValue,
+        setting.value,
+        userId,
+        'Setting updated via full update',
+      );
+    }
+
+    return this.toResponseDto(updatedSetting);
+  }
+
+  async delete(id: string, userId?: string): Promise<void> {
+    const setting = await this.settingRepository.findOne({
+      where: { id },
+    });
+
+    if (!setting) {
+      throw new NotFoundException('Setting not found');
+    }
+
+    if (setting.isReadonly) {
+      throw new ForbiddenException('This setting is read-only');
+    }
+
+    await this.logSettingChange(
+      setting,
+      SettingChangeType.DELETED,
+      setting.value,
+      null,
+      userId,
+      'Setting deleted',
+    );
+
+    await this.settingRepository.remove(setting);
+  }
+
+  async getCategories(): Promise<{ category: SettingCategory; count: number }[]> {
+    const result = await this.settingRepository
+      .createQueryBuilder('setting')
+      .select('setting.category', 'category')
+      .addSelect('COUNT(*)', 'count')
+      .where('setting.isActive = true')
+      .groupBy('setting.category')
+      .orderBy('setting.category', 'ASC')
+      .getRawMany();
+
+    return result.map(item => ({
+      category: item.category,
+      count: parseInt(item.count, 10),
+    }));
+  }
+
+  async getCompanySettings(
+    companyId: string,
+    query?: SettingQueryDto,
+  ): Promise<SettingResponseDto[]> {
+    const companyQuery: SettingQueryDto = {
+      ...query,
+      companyId,
+      scope: SettingScope.COMPANY,
+    };
+
+    return this.findAll(companyQuery);
+  }
+
+  async createBackup(
+    scope?: SettingScope,
+    companyId?: string,
+    description?: string,
+  ): Promise<SettingsBackupDto> {
+    const queryBuilder = this.settingRepository.createQueryBuilder('setting');
+
+    if (scope) {
+      queryBuilder.where('setting.scope = :scope', { scope });
+    }
+
+    if (companyId) {
+      queryBuilder.andWhere('setting.companyId = :companyId', { companyId });
+    }
+
+    const settings = await queryBuilder.getMany();
+
+    return {
+      settings: settings.map(setting => this.toResponseDto(setting)),
+      version: '1.0.0',
+      createdAt: new Date().toISOString(),
+      description,
+    };
+  }
+
+  async restoreFromBackup(
+    backupData: RestoreSettingsDto,
+    userId?: string,
+  ): Promise<{ created: number; updated: number; errors: string[] }> {
+    let created = 0;
+    let updated = 0;
+    const errors: string[] = [];
+
+    for (const settingData of backupData.settings) {
+      try {
+        const existing = await this.settingRepository.findOne({
+          where: {
+            key: settingData.key,
+            scope: settingData.scope,
+            companyId: settingData.companyId ? settingData.companyId : IsNull(),
+          },
+        });
+
+        if (existing) {
+          if (existing.isReadonly) {
+            errors.push(`Setting ${settingData.key} is read-only and cannot be restored`);
+            continue;
+          }
+
+          const oldValue = existing.value;
+          Object.assign(existing, settingData);
+          existing.updatedBy = userId ?? 'system';
+
+          if (settingData.value !== undefined) {
+            existing.setValue(settingData.value);
+          }
+
+          await this.settingRepository.save(existing);
+
+          await this.logSettingChange(
+            existing,
+            SettingChangeType.RESTORED,
+            oldValue,
+            existing.value,
+            userId,
+            backupData.reason,
+          );
+
+          updated++;
+        } else {
+          const newSetting = await this.create(settingData, userId);
+          created++;
+        }
+      } catch (error) {
+        errors.push(`Error restoring setting ${settingData.key}: ${error.message}`);
+      }
+    }
+
+    return { created, updated, errors };
+  }
+
+  async getSettingHistory(
+    key: string,
+    companyId?: string,
+    limit = 50,
+  ): Promise<SettingHistory[]> {
+    const setting = await this.getSettingByKey(key, companyId);
+
+    return this.settingHistoryRepository.find({
+      where: { settingId: setting.id },
+      relations: ['changedByUser'],
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+  }
+
+  private async getSettingByKey(
+    key: string,
+    companyId?: string,
+  ): Promise<Setting> {
+    const queryBuilder = this.settingRepository.createQueryBuilder('setting');
+
+    queryBuilder.where('setting.key = :key', { key });
+
+    if (companyId) {
+      queryBuilder.andWhere(
+        '(setting.companyId = :companyId OR (setting.scope = :systemScope AND setting.companyId IS NULL))',
+        { companyId, systemScope: SettingScope.SYSTEM },
+      );
+      queryBuilder.orderBy(
+        'CASE WHEN setting.companyId = :companyId THEN 0 ELSE 1 END',
+        'ASC',
+      );
+    } else {
+      queryBuilder.andWhere('setting.companyId IS NULL');
+    }
+
+    const setting = await queryBuilder.getOne();
+
+    if (!setting) {
+      throw new NotFoundException(`Setting with key '${key}' not found`);
+    }
+
+    return setting;
+  }
+
+  private validateSettingValue(setting: Setting, value: any): void {
+    if (!setting.validation) return;
+
+    const { validation } = setting;
+
+    if (validation.required && (value === null || value === undefined || value === '')) {
+      throw new BadRequestException('This setting is required');
+    }
+
+    switch (setting.type) {
+      case SettingType.NUMBER:
+        const numValue = parseFloat(value);
+        if (isNaN(numValue)) {
+          throw new BadRequestException('Value must be a valid number');
+        }
+        if (validation.min !== undefined && numValue < validation.min) {
+          throw new BadRequestException(`Value must be at least ${validation.min}`);
+        }
+        if (validation.max !== undefined && numValue > validation.max) {
+          throw new BadRequestException(`Value must be at most ${validation.max}`);
+        }
+        break;
+
+      case SettingType.STRING:
+        const strValue = value.toString();
+        if (validation.minLength !== undefined && strValue.length < validation.minLength) {
+          throw new BadRequestException(`Value must be at least ${validation.minLength} characters`);
+        }
+        if (validation.maxLength !== undefined && strValue.length > validation.maxLength) {
+          throw new BadRequestException(`Value must be at most ${validation.maxLength} characters`);
+        }
+        if (validation.pattern) {
+          const regex = new RegExp(validation.pattern);
+          if (!regex.test(strValue)) {
+            throw new BadRequestException('Value does not match required pattern');
+          }
+        }
+        if (validation.options && !validation.options.includes(strValue)) {
+          throw new BadRequestException(`Value must be one of: ${validation.options.join(', ')}`);
+        }
+        break;
+
+      case SettingType.JSON:
+      case SettingType.ARRAY:
+        try {
+          JSON.parse(value);
+        } catch {
+          throw new BadRequestException('Value must be valid JSON');
+        }
+        break;
+
+      case SettingType.BOOLEAN:
+        const boolStr = value.toString().toLowerCase();
+        if (!['true', 'false'].includes(boolStr)) {
+          throw new BadRequestException('Value must be true or false');
+        }
+        break;
+    }
+  }
+
+private async logSettingChange(
+  setting: Setting,
+  changeType: SettingChangeType,
+  oldValue: string | null,
+  newValue: string | null,
+  userId?: string,
+  reason?: string,
+): Promise<void> {
+  const historyData = {
+    settingId: setting.id,
+    settingKey: setting.key,
+    oldValue: oldValue ?? undefined,
+    newValue: newValue ?? undefined,
+    changeType,
+    reason,
+    changedBy: userId,
+  };
+
+  const history = this.settingHistoryRepository.create(historyData);
+
+  await this.settingHistoryRepository.save(history);
+}
+  private toResponseDto(setting: Setting): SettingResponseDto {
+    return {
+      id: setting.id,
+      key: setting.key,
+      value: setting.value,
+      parsedValue: setting.getParsedValue(),
+      type: setting.type,
+      scope: setting.scope,
+      category: setting.category,
+      companyId: setting.companyId,
+      description: setting.description,
+      validation: setting.validation,
+      metadata: setting.metadata,
+      isActive: setting.isActive,
+      isReadonly: setting.isReadonly,
+      defaultValue: setting.defaultValue,
+      createdBy: setting.createdBy,
+      updatedBy: setting.updatedBy,
+      createdAt: setting.createdAt,
+      updatedAt: setting.updatedAt,
+    };
+  }
+}

--- a/src/settings/settings.controller.spec.ts
+++ b/src/settings/settings.controller.spec.ts
@@ -1,0 +1,125 @@
+import { TestingModule, Test } from "@nestjs/testing";
+import { SettingsController } from "./controllers/settings.controller";
+import { SettingType, SettingScope, SettingCategory } from "./entities/setting.entity";
+import { SettingsService } from "./services/settings.service";
+
+describe('SettingsController', () => {
+  let controller: SettingsController;
+  let service: SettingsService;
+
+  const mockSettingsService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findByKey: jest.fn(),
+    updateByKey: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    getCategories: jest.fn(),
+    createBackup: jest.fn(),
+    restoreFromBackup: jest.fn(),
+    getSettingHistory: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SettingsController],
+      providers: [
+        {
+          provide: SettingsService,
+          useValue: mockSettingsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SettingsController>(SettingsController);
+    service = module.get<SettingsService>(SettingsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create a setting', async () => {
+      const createDto = {
+        key: 'test.setting',
+        value: 'test value',
+        type: SettingType.STRING,
+        scope: SettingScope.SYSTEM,
+        category: SettingCategory.GENERAL,
+      };
+      const expectedResult = { id: '1', ...createDto };
+      const req = { user: { sub: 'user-id' } };
+
+      mockSettingsService.create.mockResolvedValue(expectedResult);
+
+      const result = await controller.create(createDto, req);
+
+      expect(service.create).toHaveBeenCalledWith(createDto, 'user-id');
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all settings', async () => {
+      const query = { scope: SettingScope.SYSTEM };
+      const expectedResult = [
+        { id: '1', key: 'setting1' },
+        { id: '2', key: 'setting2' },
+      ];
+
+      mockSettingsService.findAll.mockResolvedValue(expectedResult);
+
+      const result = await controller.findAll(query);
+
+      expect(service.findAll).toHaveBeenCalledWith(query);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('findByKey', () => {
+    it('should return setting by key', async () => {
+      const key = 'test.setting';
+      const expectedResult = { id: '1', key };
+
+      mockSettingsService.findByKey.mockResolvedValue(expectedResult);
+
+      const result = await controller.findByKey(key);
+
+      expect(service.findByKey).toHaveBeenCalledWith(key, undefined);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('updateByKey', () => {
+    it('should update setting by key', async () => {
+      const key = 'test.setting';
+      const updateDto = { value: 'new value' };
+      const req = { user: { sub: 'user-id' } };
+      const expectedResult = { id: '1', key, value: 'new value' };
+
+      mockSettingsService.updateByKey.mockResolvedValue(expectedResult);
+
+      const result = await controller.updateByKey(key, updateDto, req);
+
+      expect(service.updateByKey).toHaveBeenCalledWith(key, updateDto, 'user-id', undefined);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('getCategories', () => {
+    it('should return setting categories', async () => {
+      const expectedResult = [
+        { category: SettingCategory.GENERAL, count: 5 },
+        { category: SettingCategory.SECURITY, count: 3 },
+      ];
+
+      mockSettingsService.getCategories.mockResolvedValue(expectedResult);
+
+      const result = await controller.getCategories();
+
+      expect(service.getCategories).toHaveBeenCalled();
+      expect(result).toEqual(expectedResult);
+    });
+  });
+});

--- a/src/settings/settings.module.ts
+++ b/src/settings/settings.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Setting } from './entities/setting.entity';
+import { SettingHistory } from './entities/setting-history.entity';
+import { SettingsService } from './services/settings.service';
+import { SettingsController } from './controllers/settings.controller';
+import { CompanySettingsController } from './controllers/company-settings.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Setting, SettingHistory])],
+  controllers: [SettingsController, CompanySettingsController],
+  providers: [SettingsService],
+  exports: [SettingsService],
+})
+export class SettingsModule {}

--- a/src/settings/settings.service.spec.ts
+++ b/src/settings/settings.service.spec.ts
@@ -1,0 +1,468 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SettingsService } from './services/settings.service';
+import {
+  Setting,
+  SettingScope,
+  SettingType,
+  SettingCategory,
+} from './entities/setting.entity';
+import { SettingHistory } from './entities/setting-history.entity';
+import {
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+  let settingRepository: Repository<Setting>;
+  let historyRepository: Repository<SettingHistory>;
+
+  const mockSettingRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    createQueryBuilder: jest.fn(() => ({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      getMany: jest.fn(),
+      getOne: jest.fn(),
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn(),
+    })),
+    remove: jest.fn(),
+  };
+
+  const mockHistoryRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SettingsService,
+        {
+          provide: getRepositoryToken(Setting),
+          useValue: mockSettingRepository,
+        },
+        {
+          provide: getRepositoryToken(SettingHistory),
+          useValue: mockHistoryRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SettingsService>(SettingsService);
+    settingRepository = module.get<Repository<Setting>>(
+      getRepositoryToken(Setting),
+    );
+    historyRepository = module.get<Repository<SettingHistory>>(
+      getRepositoryToken(SettingHistory),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const createSettingDto = {
+      key: 'test.setting',
+      value: 'test value',
+      type: SettingType.STRING,
+      scope: SettingScope.SYSTEM,
+      category: SettingCategory.GENERAL,
+    };
+
+    it('should create a new setting successfully', async () => {
+      const mockSetting = {
+        id: '1',
+        ...createSettingDto,
+        setValue: jest.fn(),
+        getParsedValue: jest.fn().mockReturnValue('test value'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockSettingRepository.findOne.mockResolvedValue(null);
+      mockSettingRepository.create.mockReturnValue(mockSetting);
+      mockSettingRepository.save.mockResolvedValue(mockSetting);
+      mockHistoryRepository.create.mockReturnValue({});
+      mockHistoryRepository.save.mockResolvedValue({});
+
+      const result = await service.create(createSettingDto, 'user-id');
+
+      expect(mockSettingRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          key: createSettingDto.key,
+          scope: createSettingDto.scope,
+          companyId: expect.any(Object),
+        },
+      });
+      expect(mockSettingRepository.create).toHaveBeenCalledWith({
+        ...createSettingDto,
+        createdBy: 'user-id',
+        updatedBy: 'user-id',
+      });
+      expect(mockSettingRepository.save).toHaveBeenCalledWith(mockSetting);
+      expect(result.key).toBe(createSettingDto.key);
+    });
+
+    it('should throw ConflictException if setting already exists', async () => {
+      const existingSetting = { id: '1', ...createSettingDto };
+      mockSettingRepository.findOne.mockResolvedValue(existingSetting);
+
+      await expect(service.create(createSettingDto, 'user-id')).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('should throw BadRequestException for company scope without companyId', async () => {
+      const invalidDto = {
+        ...createSettingDto,
+        scope: SettingScope.COMPANY,
+      };
+
+      mockSettingRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.create(invalidDto, 'user-id')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('findByKey', () => {
+    it('should find setting by key', async () => {
+      const mockSetting = {
+        id: '1',
+        key: 'test.setting',
+        value: 'test value',
+        getParsedValue: jest.fn().mockReturnValue('test value'),
+        type: SettingType.STRING,
+        scope: SettingScope.SYSTEM,
+        category: SettingCategory.GENERAL,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const queryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockSetting),
+        getMany: jest.fn().mockResolvedValue([]),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      mockSettingRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+      const result = await service.findByKey('test.setting');
+
+      expect(queryBuilder.where).toHaveBeenCalledWith('setting.key = :key', {
+        key: 'test.setting',
+      });
+      expect(result.key).toBe('test.setting');
+    });
+
+    it('should throw NotFoundException if setting not found', async () => {
+      const queryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+        getMany: jest.fn().mockResolvedValue([]),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      mockSettingRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+      await expect(service.findByKey('nonexistent.setting')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('updateByKey', () => {
+    const mockSetting = {
+      id: '1',
+      key: 'test.setting',
+      value: 'old value',
+      isReadonly: false,
+      setValue: jest.fn(),
+      getParsedValue: jest.fn().mockReturnValue('new value'),
+      type: SettingType.STRING,
+      validation: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('should update setting value successfully', async () => {
+      const updateDto = { value: 'new value' };
+      const queryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(mockSetting),
+        getMany: jest.fn().mockResolvedValue([]),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      mockSettingRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+      mockSettingRepository.save.mockResolvedValue({
+        ...mockSetting,
+        value: 'new value',
+      });
+      mockHistoryRepository.create.mockReturnValue({});
+      mockHistoryRepository.save.mockResolvedValue({});
+
+      const result = await service.updateByKey(
+        'test.setting',
+        updateDto,
+        'user-id',
+      );
+
+      expect(mockSetting.setValue).toHaveBeenCalledWith('new value');
+      expect(mockSettingRepository.save).toHaveBeenCalled();
+      expect(result.key).toBe('test.setting');
+    });
+
+    it('should throw ForbiddenException for readonly setting', async () => {
+      const readonlySetting = { ...mockSetting, isReadonly: true };
+      const queryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(readonlySetting),
+        getMany: jest.fn().mockResolvedValue([]),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      mockSettingRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+      await expect(
+        service.updateByKey('test.setting', { value: 'new value' }, 'user-id'),
+      ).rejects.toThrow('This setting is read-only');
+    });
+  });
+
+  describe('validation', () => {
+    it('should validate number settings', async () => {
+      const mockSetting = {
+        type: SettingType.NUMBER,
+        validation: { min: 10, max: 100, required: true },
+      } as Setting;
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, '50'),
+      ).not.toThrow();
+
+      expect(() => service['validateSettingValue'](mockSetting, '5')).toThrow(
+        BadRequestException,
+      );
+
+      expect(() => service['validateSettingValue'](mockSetting, '150')).toThrow(
+        BadRequestException,
+      );
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, 'not-a-number'),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should validate string settings', async () => {
+      const mockSetting = {
+        type: SettingType.STRING,
+        validation: {
+          minLength: 3,
+          maxLength: 10,
+          options: ['option1', 'option2'],
+          pattern: '^[a-z0-9]+$',
+        },
+      } as Setting;
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, 'option1'),
+      ).not.toThrow();
+
+      expect(() => service['validateSettingValue'](mockSetting, 'ab')).toThrow(
+        BadRequestException,
+      );
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, 'verylongstring'),
+      ).toThrow(BadRequestException);
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, 'option3'),
+      ).toThrow(BadRequestException);
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, 'OPTION1'),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should validate boolean settings', async () => {
+      const mockSetting = {
+        type: SettingType.BOOLEAN,
+        validation: {},
+      } as Setting;
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, 'true'),
+      ).not.toThrow();
+      expect(() =>
+        service['validateSettingValue'](mockSetting, 'false'),
+      ).not.toThrow();
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, 'maybe'),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should validate JSON settings', async () => {
+      const mockSetting = {
+        type: SettingType.JSON,
+        validation: {},
+      } as Setting;
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, '{"key": "value"}'),
+      ).not.toThrow();
+
+      expect(() =>
+        service['validateSettingValue'](mockSetting, '{invalid json}'),
+      ).toThrow(BadRequestException);
+    });
+
+    it('should validate required settings', async () => {
+      const mockSetting = {
+        type: SettingType.STRING,
+        validation: { required: true },
+      } as Setting;
+
+      expect(() => service['validateSettingValue'](mockSetting, '')).toThrow(
+        BadRequestException,
+      );
+      expect(() => service['validateSettingValue'](mockSetting, null)).toThrow(
+        BadRequestException,
+      );
+      expect(() =>
+        service['validateSettingValue'](mockSetting, undefined),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  describe('backup and restore', () => {
+    it('should create backup successfully', async () => {
+      const mockSettings = [
+        {
+          id: '1',
+          key: 'test.setting1',
+          value: 'value1',
+          getParsedValue: () => 'value1',
+          type: SettingType.STRING,
+          scope: SettingScope.SYSTEM,
+          category: SettingCategory.GENERAL,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: '2',
+          key: 'test.setting2',
+          value: 'value2',
+          getParsedValue: () => 'value2',
+          type: SettingType.STRING,
+          scope: SettingScope.SYSTEM,
+          category: SettingCategory.GENERAL,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      const queryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getOne: jest.fn().mockResolvedValue(null),
+        getMany: jest.fn().mockResolvedValue(mockSettings),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      mockSettingRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+
+      const result = await service.createBackup(
+        SettingScope.SYSTEM,
+        undefined,
+        'Test backup',
+      );
+
+      expect(result.settings).toHaveLength(2);
+      expect(result.version).toBe('1.0.0');
+      expect(result.description).toBe('Test backup');
+    });
+
+    it('should restore from backup successfully', async () => {
+      const backupData = {
+        settings: [
+          {
+            key: 'new.setting',
+            value: 'new value',
+            type: SettingType.STRING,
+            scope: SettingScope.SYSTEM,
+            category: SettingCategory.GENERAL,
+          },
+        ],
+        reason: 'Test restore',
+      };
+
+      mockSettingRepository.findOne.mockResolvedValue(null);
+      const mockNewSetting = {
+        id: '1',
+        ...backupData.settings[0],
+        setValue: jest.fn(),
+        // setParsedValue: jest.fn(),
+        getParsedValue: jest.fn().mockReturnValue('new value'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        createdBy: 'user-id',
+        updatedBy: 'user-id',
+      };
+      mockSettingRepository.create.mockReturnValue(mockNewSetting);
+      mockSettingRepository.save.mockResolvedValue(mockNewSetting);
+      mockHistoryRepository.create.mockReturnValue({});
+      mockHistoryRepository.save.mockResolvedValue({});
+
+      const result = await service.restoreFromBackup(backupData, 'user-id');
+
+      expect(result.created).toBe(1);
+      expect(result.updated).toBe(0);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
   }
 }


### PR DESCRIPTION
closes #138 

### Description
This PR implements a comprehensive Settings Resource Module for managing system-wide and company-specific configuration settings with validation, change tracking, and backup/restore functionality.

### Changes made
Implemented Settings entity with scope and validation, SettingsService with complete settings management, SettingsController with REST endpoints, setting categories and grouping, change history tracking, and backup/restore capabilities with proper multi-tenancy support.


### How to run
`npm run test settings`

All test passed
<img width="960" height="504" alt="image" src="https://github.com/user-attachments/assets/0e32f146-87e3-41bd-bb7b-f96d1d99b0b3" />
